### PR TITLE
Improve dark theme and blog styling

### DIFF
--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -56,7 +56,7 @@ const Blog = () => {
           {blogPosts.map((post, index) => (
             <article 
               key={index}
-              className="bg-slate-800/50 backdrop-blur-sm rounded-xl overflow-hidden border border-purple-500/20 hover:border-purple-400/50 transition-all duration-300 hover:scale-105 group cursor-pointer"
+              className="bg-black/50 backdrop-blur-sm rounded-xl overflow-hidden border border-purple-500/20 hover:border-purple-400/50 transition-all duration-300 hover:scale-105 group cursor-pointer"
             >
               <div className="relative overflow-hidden">
                 <img 

--- a/src/index.css
+++ b/src/index.css
@@ -49,40 +49,41 @@
   }
 
   .dark {
-    --background: 220 13% 18%;
+    /* Black-ish theme */
+    --background: 0 0% 8%;
     --foreground: 210 40% 98%;
 
-    --card: 220 13% 18%;
+    --card: 0 0% 8%;
     --card-foreground: 210 40% 98%;
 
-    --popover: 220 13% 18%;
+    --popover: 0 0% 8%;
     --popover-foreground: 210 40% 98%;
 
     --primary: 210 40% 98%;
     --primary-foreground: 222.2 47.4% 11.2%;
 
-    --secondary: 217.2 32.6% 17.5%;
+    --secondary: 0 0% 18%;
     --secondary-foreground: 210 40% 98%;
 
-    --muted: 217.2 32.6% 17.5%;
+    --muted: 0 0% 18%;
     --muted-foreground: 215 20.2% 65.1%;
 
-    --accent: 217.2 32.6% 17.5%;
+    --accent: 0 0% 18%;
     --accent-foreground: 210 40% 98%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 220 13% 15%;
-    --sidebar-foreground: 210 40% 95%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 0 0% 60%;
+    --sidebar-background: 0 0% 5%;
+    --sidebar-foreground: 0 0% 90%;
     --sidebar-primary: 224.3 76.3% 48%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 217.2 32.6% 17.5%;
-    --sidebar-accent-foreground: 210 40% 95%;
-    --sidebar-border: 217.2 32.6% 17.5%;
+    --sidebar-accent: 0 0% 18%;
+    --sidebar-accent-foreground: 0 0% 90%;
+    --sidebar-border: 0 0% 20%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
 }
@@ -102,7 +103,7 @@
   }
 
   .dark body {
-    @apply bg-slate-800 text-gray-100;
+    @apply bg-black text-gray-100;
   }
 
   body {

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -58,7 +58,7 @@ const Blog = () => {
   const categories = ['All', 'Theory', 'Tutorial', 'Research', 'Beginner', 'Technical'];
 
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 pt-20">
+    <div className="min-h-screen bg-white dark:bg-black text-gray-900 dark:text-gray-100 pt-20">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="py-16 text-center">
@@ -86,11 +86,11 @@ const Blog = () => {
             <Link
               key={index}
               to={`/blog/${post.slug}`}
-              className="group bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-2xl hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-300"
+              className="group bg-white dark:bg-black border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-2xl hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-300"
             >
               <div className="p-6">
                 <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400 mb-3">
-                  <span className="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded-full text-xs">
+                  <span className="px-2 py-1 bg-gray-100 dark:bg-neutral-800 rounded-full text-xs">
                     {post.category}
                   </span>
                   <div className="flex items-center gap-1">

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -117,7 +117,7 @@ const BlogPost = () => {
 
   if (!currentPost) {
     return (
-      <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 pt-20">
+      <div className="min-h-screen bg-white dark:bg-black text-gray-900 dark:text-gray-100 pt-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
           <h1 className="text-4xl font-bold mb-4">Blog Post Not Found</h1>
           <p className="text-gray-600 dark:text-gray-400 mb-8">The blog post you're looking for doesn't exist.</p>
@@ -142,9 +142,9 @@ const BlogPost = () => {
   };
 
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <div className="min-h-screen bg-white dark:bg-black text-gray-900 dark:text-gray-100">
       {/* Header with navigation */}
-      <div className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pt-20">
+      <div className="bg-white dark:bg-black border-b border-gray-200 dark:border-gray-700 pt-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <Link 
             to="/blog" 
@@ -155,7 +155,7 @@ const BlogPost = () => {
           </Link>
           
           <div className="mb-6">
-            <span className="px-3 py-1 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm rounded-full">
+            <span className="px-3 py-1 bg-gray-100 dark:bg-neutral-800 text-gray-700 dark:text-gray-300 text-sm rounded-full">
               {currentPost.category}
             </span>
           </div>
@@ -183,7 +183,7 @@ const BlogPost = () => {
             
             <button
               onClick={handleShare}
-              className="flex items-center gap-2 px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors"
+              className="flex items-center gap-2 px-4 py-2 bg-gray-100 dark:bg-neutral-800 hover:bg-gray-200 dark:hover:bg-neutral-700 rounded-lg transition-colors"
             >
               <Share2 size={16} />
               Share
@@ -206,7 +206,7 @@ const BlogPost = () => {
           {prevPost && (
             <Link
               to={`/blog/${prevPost.slug}`}
-              className="group p-6 bg-gray-50 dark:bg-gray-800 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              className="group p-6 bg-gray-50 dark:bg-neutral-800 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-700 transition-colors"
             >
               <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400 mb-2">
                 <ArrowLeft size={16} />
@@ -221,7 +221,7 @@ const BlogPost = () => {
           {nextPost && (
             <Link
               to={`/blog/${nextPost.slug}`}
-              className="group p-6 bg-gray-50 dark:bg-gray-800 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors md:text-right"
+              className="group p-6 bg-gray-50 dark:bg-neutral-800 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-700 transition-colors md:text-right"
             >
               <div className="flex items-center justify-end gap-2 text-gray-600 dark:text-gray-400 mb-2">
                 <span className="text-sm">Next Post</span>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -81,7 +81,7 @@ const Home = () => {
         <meta property="og:description" content="Research blog with insights into diffusion models and AI." />
       </Helmet>
 
-      <div className="min-h-screen bg-white dark:bg-slate-800 text-black dark:text-white">
+  <div className="min-h-screen bg-white dark:bg-black text-black dark:text-white">
         {/* Hero Section */}
         <section className="pt-20 pb-16 px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl mx-auto text-center">
@@ -115,7 +115,7 @@ const Home = () => {
         </section>
 
         {/* Recent Blog Posts */}
-        <section className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-900">
+        <section className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-black">
           <div className="max-w-6xl mx-auto">
             <div className="flex justify-between items-center mb-12">
               <div>
@@ -137,7 +137,7 @@ const Home = () => {
                 <Link
                   key={index}
                   to={`/blog/${post.slug}`}
-                  className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:shadow-lg dark:hover:shadow-2xl transition-all duration-300 group"
+                  className="bg-white dark:bg-black border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:shadow-purple-500/25 dark:hover:shadow-purple-500/25 hover:border-purple-500 dark:hover:border-purple-500 transition-all duration-300 group"
                 >
                   <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400 mb-3">
                     <div className="flex items-center gap-1">
@@ -185,7 +185,7 @@ const Home = () => {
 
             <div className="grid md:grid-cols-2 gap-8">
               {recentPublications.map((pub, index) => (
-                <div key={index} className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:shadow-lg dark:hover:shadow-2xl transition-all duration-300">
+                <div key={index} className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 hover:shadow-purple-500/25 dark:hover:shadow-purple-500/25 hover:border-purple-500 dark:hover:border-purple-500 transition-all duration-300">
                   <h3 className="text-xl font-bold mb-3">{pub.title}</h3>
                   <p className="text-gray-600 dark:text-gray-400 mb-2">{pub.authors}</p>
                   <p className="text-gray-600 dark:text-gray-400 font-medium">{pub.venue} ({pub.year})</p>
@@ -196,7 +196,7 @@ const Home = () => {
         </section>
 
         {/* Publication Reviews */}
-        <section className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-900">
+        <section className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-black">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12">
               <h2 className="text-3xl font-bold mb-4">Publication Reviews & Commentary</h2>
@@ -207,7 +207,7 @@ const Home = () => {
 
             <div className="space-y-8">
               {publicationReviews.map((review, index) => (
-                <div key={index} className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-gray-700 rounded-lg p-8">
+                <div key={index} className="bg-white dark:bg-black border border-gray-200 dark:border-gray-700 rounded-lg p-8 hover:shadow-purple-500/25 dark:hover:shadow-purple-500/25 transition-shadow">
                   <div className="flex justify-between items-start mb-4">
                     <div>
                       <h3 className="text-xl font-bold mb-2">{review.title}</h3>
@@ -222,7 +222,7 @@ const Home = () => {
                       ))}
                     </div>
                   </div>
-                  <div className="border-l-4 border-gray-300 dark:border-gray-600 pl-4">
+                  <div className="border-l-4 border-purple-500 dark:border-purple-500/80 pl-4">
                     <p className="text-gray-700 dark:text-gray-300 italic leading-relaxed">
                       "{review.myReview}"
                     </p>
@@ -244,7 +244,7 @@ const Home = () => {
               <input
                 type="email"
                 placeholder="Enter your email"
-                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white"
+                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-black focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white"
               />
               <button className="px-6 py-2 bg-black dark:bg-white text-white dark:text-black rounded-lg font-medium hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors">
                 Subscribe

--- a/src/pages/Research.tsx
+++ b/src/pages/Research.tsx
@@ -126,7 +126,7 @@ const Research = () => {
                   {project.tech.map((tech, techIndex) => (
                     <span 
                       key={techIndex}
-                      className="px-2 py-1 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded text-sm"
+                      className="px-2 py-1 bg-gray-100 dark:bg-neutral-800 text-gray-700 dark:text-gray-300 rounded text-sm"
                     >
                       {tech}
                     </span>


### PR DESCRIPTION
## Summary
- adjust dark theme colors for a consistent black look
- update body styles for dark mode
- refine home page blog and paper review cards
- tweak blog list and post pages for the new palette
- minor update to research page tags

## Testing
- `npm run lint` *(fails: @typescript-eslint issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68620d4cf7fc83329f822599855bc72c